### PR TITLE
Add support for G20/G21 and inch mode

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -87,6 +87,8 @@
  * G4  - Dwell S<seconds> or P<milliseconds>
  * G10 - retract filament according to settings of M207
  * G11 - retract recover filament according to settings of M208
+ * G20 - Set input units to inches
+ * G21 - Set input units to millimeters
  * G28 - Home one or more axes
  * G29 - Detailed Z probe, probes the bed at 3 or more points.  Will fail if you haven't homed yet.
  * G30 - Single Z probe, probes bed at current XY location.


### PR DESCRIPTION
Inch mode is common in generated G-code for CNC machines. This approach
to integrating an inch mode avoids having to update any internal
algorithms or constants by converting values as they are read in from
the G-code file.
